### PR TITLE
feat: expose CU pricing in websocket payload

### DIFF
--- a/src/domain/recommendation.ts
+++ b/src/domain/recommendation.ts
@@ -18,17 +18,19 @@ const toSOL = (lamports: number): number => {
 }
 
 const buildRecommendation = (params: IBuildRecommendationParams ): Recommendation => {
-	const feeLamports = computeFeeLamports(params.cuPriceMicroLamports, params.cuEstimate);
-	const feeSOL = toSOL(feeLamports);
-	const success = successFromLatencyMs(params.latencyMs, params.risk);
-	return {
-		feeLamports,
-		feeSOL,
-		success,
-		recommendedRpc: params.rpc,
-		updatedAt: params.timestamp ?? Date.now(),
-		notes: params.notes ?? []
-	};
+        const feeLamports = computeFeeLamports(params.cuPriceMicroLamports, params.cuEstimate);
+        const feeSOL = toSOL(feeLamports);
+        const success = successFromLatencyMs(params.latencyMs, params.risk);
+        return {
+                cuPriceMicroLamports: params.cuPriceMicroLamports,
+                cuEstimate: params.cuEstimate,
+                feeLamports,
+                feeSOL,
+                success,
+                recommendedRpc: params.rpc,
+                updatedAt: params.timestamp ?? Date.now(),
+                notes: params.notes ?? []
+        };
 }
 
 export {

--- a/src/infrastructure/ws/wsGateway.ts
+++ b/src/infrastructure/ws/wsGateway.ts
@@ -34,22 +34,23 @@ class WsGateway {
 		ws.on("error", () => this.clients.delete(state));
 	}
 
-	broadcast(recos: Record<Risk, Recommendation>) {
-		const payloads: Partial<Record<Risk, string>> = {};
-		const enc = (r: Risk) =>
-			(payloads[r] ??= JSON.stringify({
-				priorityFeeSOL: recos[r].feeSOL,
-				priorityFeeLamports: recos[r].feeLamports,
-				successScore: recos[r].success,
-				recommendedRpc: recos[r].recommendedRpc,
-				updatedAt: new Date(recos[r].updatedAt).toISOString(),
-				notes: recos[r].notes,
-				stale: recos[r].stale,
-			}));
-		for (const c of this.clients) {
-			if (c.ws.readyState !== c.ws.OPEN) continue;
-			try {
-				c.ws.send(enc(c.risk));
+        broadcast(recos: Record<Risk, Recommendation>) {
+                const payloads: Partial<Record<Risk, string>> = {};
+                const enc = (r: Risk) =>
+                        (payloads[r] ??= JSON.stringify({
+                                mode: r,
+                                cuPrice: recos[r].cuPriceMicroLamports,
+                                cuEstimate: recos[r].cuEstimate,
+                                priorityFeeLamports: recos[r].feeLamports,
+                                successScore: recos[r].success,
+                                recommendedRpc: recos[r].recommendedRpc,
+                                updatedAt: new Date(recos[r].updatedAt).toISOString(),
+                                notes: recos[r].notes,
+                        }));
+                for (const c of this.clients) {
+                        if (c.ws.readyState !== c.ws.OPEN) continue;
+                        try {
+                                c.ws.send(enc(c.risk));
 				c.lastSentAt = Date.now();
 			} catch (error) {
 				console.error("[ws] send error:", error);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -12,13 +12,15 @@ export interface NetworkSnapshot {
 }
 
 export interface Recommendation {
-	feeLamports: number;         // итог в лампортах
-	feeSOL: number;              // feeLamports / 1e9
-	success: number;             // 0..1
-	recommendedRpc: string;
-	updatedAt: number;           // Date.now()
-	notes?: string[];
-	stale?: boolean;
+        cuPriceMicroLamports: number; // цена в µлампортах за единицу CU
+        cuEstimate: number;           // оценка CU для транзакции
+        feeLamports: number;          // итог в лампортах
+        feeSOL: number;               // feeLamports / 1e9
+        success: number;              // 0..1
+        recommendedRpc: string;
+        updatedAt: number;            // Date.now()
+        notes?: string[];
+        stale?: boolean;
 }
 export interface RpcInfo {
 	endpoint: string;


### PR DESCRIPTION
## Summary
- include CU price and estimate in recommendation data
- reshape WebSocket payload to provide CU metrics and mode

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a3c60c81c4832aa9686fce45aec759