### PR TITLE
ci: разделить проверки PR и прод-выкладку

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: CI/CD
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 permissions:
   contents: read
@@ -17,9 +19,46 @@ env:
   IMAGE: ghcr.io/toxanetoxa/solana-server-helper # ghcr.io/owner/repo (должно быть в нижнем регистре)
 
 jobs:
+  pr-checks:
+    name: PR Checks
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run ESLint
+        run: pnpm run lint
+
+      - name: Run TypeScript typecheck
+        run: pnpm run typecheck
+
+      - name: Run unit & integration tests
+        run: pnpm run test
+
+      - name: Ensure project builds
+        run: pnpm run build
+
   build:
     name: Build & Publish Image
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,6 +90,7 @@ jobs:
   prepare-deploy:
     name: Prepare Remote Host
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     needs: build
     steps:
       - name: Ensure deploy directory exists
@@ -127,6 +167,7 @@ jobs:
   deploy:
     name: Rollout Containers
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     needs: prepare-deploy
     steps:
       - name: Deploy on VDS via SSH

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "tsx watch src/main.ts",
     "start": "node dist/main.js",
     "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
Обновлён tsconfig.json: тестовые файлы src/**/*.test.ts и src/**/*.spec.ts исключены из компиляции, чтобы Docker-сборка проходила без подключения dev-зависимостей. В package.json добавлен скрипт typecheck (tsc --noEmit) для статической проверки типов. Workflow CI/CD теперь разделён:
Для pull_request добавлен job PR Checks, который выполняет pnpm run lint, pnpm run typecheck, pnpm run test и pnpm run build — merge невозможен при падении проверок. Сборка образа и деплой (build, prepare-deploy, deploy) запускаются только при push в main, сохранив прежнюю цепочку выкладки.